### PR TITLE
Fix missing include directory for tcdm_interconnect

### DIFF
--- a/src_files.yml
+++ b/src_files.yml
@@ -40,6 +40,7 @@ peripheral_interco:
   ]
 tcdm_interconnect:
   incdirs: [
+    rtl/low_latency_interco
   ]
   files: [
     rtl/tcdm_interconnect/tcdm_interconnect_pkg.sv,


### PR DESCRIPTION
If tcdm_interconnect is used without other interconnect components, parameters.v isn't included.