### PR TITLE
Fix: parametrize CLUSTER_ALIAS in XBAR_PE

### DIFF
--- a/rtl/peripheral_interco/AddressDecoder_PE_Req.sv
+++ b/rtl/peripheral_interco/AddressDecoder_PE_Req.sv
@@ -43,7 +43,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 `include "parameters.v"
-`include "pulp_soc_defines.sv"
 
 module AddressDecoder_PE_Req 
 #(
@@ -54,6 +53,7 @@ module AddressDecoder_PE_Req
     parameter ADDR_WIDTH     = 32,
     parameter PE_ROUTING_LSB = 16,
     parameter PE_ROUTING_MSB = 19,
+    parameter CLUSTER_ALIAS  = 1'b0,
     parameter CLUSTER_ALIAS_BASE = 12'h000
 ) 
 (
@@ -89,14 +89,9 @@ module AddressDecoder_PE_Req
       end
  
 
-      // FIXME -- Not parameteric
       always_comb
       begin
-      `ifdef CLUSTER_ALIAS
-          if( ( data_add_i[31:20] >= PE_START) && ( data_add_i[31:20] < PE_END ) ||  ( data_add_i[31:20] >= (CLUSTER_ALIAS_BASE+2) ) && ( data_add_i[31:20] < (CLUSTER_ALIAS_BASE+3) ) )
-      `else
-          if( ( data_add_i[31:20] >= PE_START ) && ( data_add_i[31:20] < PE_END ) )
-      `endif
+          if( ( data_add_i[31:20] >= PE_START ) && ( data_add_i[31:20] < PE_END ) || ( CLUSTER_ALIAS && ( ( data_add_i[31:20] >= (CLUSTER_ALIAS_BASE+2) ) && ( data_add_i[31:20] < (CLUSTER_ALIAS_BASE+3) ) ) ) )
               ROUTING_ADDR = data_add_i[PE_ROUTING_MSB:PE_ROUTING_LSB];
           else
               ROUTING_ADDR = '1;

--- a/rtl/peripheral_interco/ResponseBlock_PE.sv
+++ b/rtl/peripheral_interco/ResponseBlock_PE.sv
@@ -57,6 +57,7 @@ module ResponseBlock_PE
     parameter ADDR_WIDTH     = 32,
     parameter PE_ROUTING_LSB = 16,
     parameter PE_ROUTING_MSB = 19,
+    parameter CLUSTER_ALIAS  = 1'b0,
     parameter CLUSTER_ALIAS_BASE = 12'h000
 )
 (
@@ -168,6 +169,7 @@ module ResponseBlock_PE
           .ADDR_WIDTH      ( ADDR_WIDTH      ),
           .PE_ROUTING_LSB  ( PE_ROUTING_LSB  ),
           .PE_ROUTING_MSB  ( PE_ROUTING_MSB  ),
+          .CLUSTER_ALIAS   ( CLUSTER_ALIAS   ),
           .CLUSTER_ALIAS_BASE (CLUSTER_ALIAS_BASE)
       )
       i_AddressDecoder_PE_Req

--- a/rtl/peripheral_interco/XBAR_PE.sv
+++ b/rtl/peripheral_interco/XBAR_PE.sv
@@ -62,6 +62,7 @@ module XBAR_PE
     parameter PE_ROUTING_LSB = 10,
     parameter PE_ROUTING_MSB = PE_ROUTING_LSB+$clog2(N_SLAVE)-1,
 
+    parameter CLUSTER_ALIAS  = 1'b0,
     parameter CLUSTER_ALIAS_BASE = 12'h000,
 
     parameter ADDR_PE_WIDTH = PE_MSB - PE_LSB + 1
@@ -273,6 +274,7 @@ module XBAR_PE
                 .ADDR_WIDTH     ( ADDR_WIDTH     ),
                 .PE_ROUTING_LSB ( PE_ROUTING_LSB ),
                 .PE_ROUTING_MSB ( PE_ROUTING_MSB ),
+                .CLUSTER_ALIAS  ( CLUSTER_ALIAS  ),
                 .CLUSTER_ALIAS_BASE (CLUSTER_ALIAS_BASE)
             ) 
             i_ResponseBlock_PE


### PR DESCRIPTION
Changes `CLUSTER_ALIAS` from define to parameter, to avoid including `pulp_soc_defines.sv`. For proper functionality when `CLUSTER_ALIAS` is defined, update to the instantiation of `XBAR_PE` is required.