### PR TITLE
Fix `variable_latency_interco` corner case 

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -7,6 +7,10 @@ dependencies:
 workspace:
   checkout_dir: "./deps"
 
+export_include_dirs:
+  - rtl/low_latency_interco
+  - rtl/peripheral_interco
+
 sources:
   # Source files grouped in levels. Files in level 0 have no dependencies on files in this
   # package. Files in level 1 only depend on files in level 0, files in level 2 on files in
@@ -29,41 +33,38 @@ sources:
   # Level 4
   - rtl/variable_latency_interconnect/variable_latency_interconnect.sv
 
-  - include_dirs:
-      - rtl/low_latency_interco
-    files:
-      - rtl/low_latency_interco/FanInPrimitive_Req.sv
-      - rtl/low_latency_interco/ArbitrationTree.sv
-      - rtl/low_latency_interco/MUX2_REQ.sv
-      - rtl/low_latency_interco/AddressDecoder_Resp.sv
-      - rtl/low_latency_interco/TestAndSet.sv
-      - rtl/low_latency_interco/RequestBlock2CH.sv
-      - rtl/low_latency_interco/RequestBlock1CH.sv
-      - rtl/low_latency_interco/FanInPrimitive_Resp.sv
-      - rtl/low_latency_interco/ResponseTree.sv
-      - rtl/low_latency_interco/ResponseBlock.sv
-      - rtl/low_latency_interco/AddressDecoder_Req.sv
-      - rtl/low_latency_interco/XBAR_TCDM.sv
-      - rtl/low_latency_interco/XBAR_TCDM_WRAPPER.sv
-      - rtl/low_latency_interco/TCDM_PIPE_REQ.sv
-      - rtl/low_latency_interco/TCDM_PIPE_RESP.sv
-      - rtl/low_latency_interco/grant_mask.sv
-      - rtl/low_latency_interco/priority_Flag_Req.sv
-  - include_dirs:
-      - rtl/peripheral_interco
-    files:
-      - rtl/peripheral_interco/AddressDecoder_PE_Req.sv
-      - rtl/peripheral_interco/AddressDecoder_Resp_PE.sv
-      - rtl/peripheral_interco/ArbitrationTree_PE.sv
-      - rtl/peripheral_interco/FanInPrimitive_Req_PE.sv
-      - rtl/peripheral_interco/RR_Flag_Req_PE.sv
-      - rtl/peripheral_interco/MUX2_REQ_PE.sv
-      - rtl/peripheral_interco/FanInPrimitive_PE_Resp.sv
-      - rtl/peripheral_interco/RequestBlock1CH_PE.sv
-      - rtl/peripheral_interco/RequestBlock2CH_PE.sv
-      - rtl/peripheral_interco/ResponseBlock_PE.sv
-      - rtl/peripheral_interco/ResponseTree_PE.sv
-      - rtl/peripheral_interco/XBAR_PE.sv
+  # Low-Latency Interco
+  - rtl/low_latency_interco/FanInPrimitive_Req.sv
+  - rtl/low_latency_interco/ArbitrationTree.sv
+  - rtl/low_latency_interco/MUX2_REQ.sv
+  - rtl/low_latency_interco/AddressDecoder_Resp.sv
+  - rtl/low_latency_interco/TestAndSet.sv
+  - rtl/low_latency_interco/RequestBlock2CH.sv
+  - rtl/low_latency_interco/RequestBlock1CH.sv
+  - rtl/low_latency_interco/FanInPrimitive_Resp.sv
+  - rtl/low_latency_interco/ResponseTree.sv
+  - rtl/low_latency_interco/ResponseBlock.sv
+  - rtl/low_latency_interco/AddressDecoder_Req.sv
+  - rtl/low_latency_interco/XBAR_TCDM.sv
+  - rtl/low_latency_interco/XBAR_TCDM_WRAPPER.sv
+  - rtl/low_latency_interco/TCDM_PIPE_REQ.sv
+  - rtl/low_latency_interco/TCDM_PIPE_RESP.sv
+  - rtl/low_latency_interco/grant_mask.sv
+  - rtl/low_latency_interco/priority_Flag_Req.sv
+
+  # Peripheral Interco
+  - rtl/peripheral_interco/AddressDecoder_PE_Req.sv
+  - rtl/peripheral_interco/AddressDecoder_Resp_PE.sv
+  - rtl/peripheral_interco/ArbitrationTree_PE.sv
+  - rtl/peripheral_interco/FanInPrimitive_Req_PE.sv
+  - rtl/peripheral_interco/RR_Flag_Req_PE.sv
+  - rtl/peripheral_interco/MUX2_REQ_PE.sv
+  - rtl/peripheral_interco/FanInPrimitive_PE_Resp.sv
+  - rtl/peripheral_interco/RequestBlock1CH_PE.sv
+  - rtl/peripheral_interco/RequestBlock2CH_PE.sv
+  - rtl/peripheral_interco/ResponseBlock_PE.sv
+  - rtl/peripheral_interco/ResponseTree_PE.sv
+  - rtl/peripheral_interco/XBAR_PE.sv
 
   - target: tcdm_test
     include_dirs:

--- a/rtl/variable_latency_interconnect/variable_latency_interconnect.sv
+++ b/rtl/variable_latency_interconnect/variable_latency_interconnect.sv
@@ -82,14 +82,18 @@ module variable_latency_interconnect import tcdm_interconnect_pkg::topo_e; #(
 
   logic [NumIn-1:0][IniAggDataWidth-1:0]  data_agg_in;
   logic [NumOut-1:0][IniAggDataWidth-1:0] data_agg_out;
-  logic [NumIn-1:0][NumOutLog2-1:0]       tgt_sel;
+  logic [NumIn-1:0][cf_math_pkg::idx_width(NumOut)-1:0] tgt_sel;
 
   for (genvar j = 0; unsigned'(j) < NumIn; j++) begin : gen_inputs
     // Extract target index
     if (NumIn == 1) begin
       assign tgt_sel[j] = '0;
     end else begin
-      assign tgt_sel[j] = req_tgt_addr_i[j][ByteOffWidth +: NumOutLog2];
+      if (NumOut == 1) begin
+        assign tgt_sel[j] = 0;
+      end else begin
+        assign tgt_sel[j] = req_tgt_addr_i[j][ByteOffWidth +: NumOutLog2];
+      end
     end
 
     // Aggregate data to be routed to targets
@@ -255,7 +259,7 @@ module variable_latency_interconnect import tcdm_interconnect_pkg::topo_e; #(
    *   Assertions   *
    ******************/
 
-  if (AddrMemWidth + NumOutLog2 > AddrWidth)
+  if (NumOut != 1 && AddrMemWidth + NumOutLog2 > AddrWidth)
     $fatal(1, "[variable_latency_interconnect] Address is not wide enough to accommodate the requested TCDM configuration.");
 
   if (Topology != tcdm_interconnect_pkg::LIC && NumOut < NumIn)


### PR DESCRIPTION
This PR fixes the behavior of the `variable_latency_interco` when `NumOut == 1`, and adds missing include directories to `Bender.yml`. 